### PR TITLE
fix: typo on additionalProperties

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -434,7 +434,7 @@ class ObjectField extends ExtensibleSchema {
               }),
               {}
             ),
-      additionaProperties: this._additionalProperties,
+      additionalProperties: this._additionalProperties,
       required: requiredFields.length ? requiredFields : undefined,
     };
   }


### PR DESCRIPTION
there is a typo here:

https://github.com/rjbma/oas-dsl/blob/6a13ed7536e44ed6c7fda1d7415ebd011fa678c5/src/index.ts#L437